### PR TITLE
Fix: wire bottomFrameContainerChild through overlay to bottom container

### DIFF
--- a/lib/src/ui/page/document_camera_frame.dart
+++ b/lib/src/ui/page/document_camera_frame.dart
@@ -422,6 +422,7 @@ class _DocumentCameraFrameState extends State<DocumentCameraFrame>
                 animationStyle: widget.animationStyle,
                 bottomHintText: widget.bottomHintText,
                 sideInfoOverlay: widget.sideInfoOverlay,
+                bottomFrameContainerChild: widget.bottomFrameContainerChild,
                 sideIndicatorStyle: widget.sideIndicatorStyle,
                 progressStyle: widget.progressStyle,
                 progressAnimation: _progressAnimation,

--- a/lib/src/ui/widgets/document_camera_overlay_layer.dart
+++ b/lib/src/ui/widgets/document_camera_overlay_layer.dart
@@ -30,6 +30,7 @@ class DocumentCameraOverlayLayer extends StatelessWidget {
   final DocumentCameraAnimationStyle animationStyle;
   final String? bottomHintText;
   final Widget? sideInfoOverlay;
+  final Widget? bottomFrameContainerChild;
   final DocumentCameraSideIndicatorStyle sideIndicatorStyle;
   final DocumentCameraProgressStyle progressStyle;
   final Animation<double>? progressAnimation;
@@ -63,6 +64,7 @@ class DocumentCameraOverlayLayer extends StatelessWidget {
     required this.animationStyle,
     required this.bottomHintText,
     required this.sideInfoOverlay,
+    this.bottomFrameContainerChild,
     required this.sideIndicatorStyle,
     required this.progressStyle,
     required this.progressAnimation,
@@ -163,6 +165,7 @@ class DocumentCameraOverlayLayer extends StatelessWidget {
             borderRadius: frameStyle.outerFrameBorderRadius,
             currentSideNotifier: logic.currentSideNotifier,
             documentDataNotifier: logic.documentDataNotifier,
+            bottomFrameContainerChild: bottomFrameContainerChild,
             bottomHintText: bottomHintText,
             sideInfoOverlay: sideInfoOverlay,
           ),


### PR DESCRIPTION
This PR fixes an issue where the bottomFrameContainerChild property exposed by DocumentCameraFrame was not being propagated to the UI layer, preventing custom widgets from rendering in the bottom frame container.

Although the property was publicly available and supported by TwoSidedBottomFrameContainer, it was never forwarded through DocumentCameraOverlayLayer, resulting in no visible effect for consumers.

This change ensures the property is correctly passed through all layers and works as intended.

Motivation
The API exposed bottomFrameContainerChild, implying customization support.
Internally, TwoSidedBottomFrameContainer already handled this property correctly.
However, the intermediate overlay layer failed to pass it along.
This created a mismatch between API expectations and actual behavior.

Fixing this aligns implementation with the public API and improves developer experience.

Changes
DocumentCameraOverlayLayer

Added:

final Widget? bottomFrameContainerChild;
Updated constructor to accept the parameter.
Forwarded the value to TwoSidedBottomFrameContainer.
DocumentCameraFrame

Passed:

bottomFrameContainerChild: widget.bottomFrameContainerChild,

when constructing DocumentCameraOverlayLayer.

Files Modified
lib/src/ui/widgets/document_camera_overlay_layer.dart
lib/src/ui/page/document_camera_frame.dart
Behavior Changes
✅ Custom widgets passed via bottomFrameContainerChild now render correctly.
❌ No breaking changes.
❌ No changes to default behavior when the property is not provided.