### PR TITLE
fix: preserve camera preview aspect ratio with cover-fit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ migrate_working_dir/
 .flutter-plugins
 .flutter-plugins-dependencies
 build/
+
+# FVM Version Cache
+.fvm/

--- a/lib/document_camera_frame.dart
+++ b/lib/document_camera_frame.dart
@@ -11,6 +11,7 @@ export 'src/services/pdf_generation_service.dart';
 
 // Models
 export 'src/models/document_capture_data.dart';
+export 'src/models/document_detection_config.dart';
 
 // Main widget
 export 'src/ui/page/document_camera_frame.dart';

--- a/lib/document_camera_frame.dart
+++ b/lib/document_camera_frame.dart
@@ -9,6 +9,7 @@ export 'src/logic/document_camera_logic.dart';
 // Models
 export 'src/models/document_capture_data.dart';
 export 'src/models/document_detection_config.dart';
+export 'src/models/document_detection_status.dart';
 // Services
 export 'src/services/cam_scanner_service.dart';
 export 'src/services/camera_service.dart';

--- a/lib/document_camera_frame.dart
+++ b/lib/document_camera_frame.dart
@@ -1,29 +1,29 @@
 // Core functionality
-export 'src/controllers/document_camera_controller.dart';
-export 'src/core/enums.dart';
+export 'package:camera/camera.dart' show FlashMode;
 
+export 'src/controllers/document_camera_controller.dart';
+export 'src/core/document_camera_style.dart';
+export 'src/core/enums.dart';
+// Logic
+export 'src/logic/document_camera_logic.dart';
+// Models
+export 'src/models/document_capture_data.dart';
+export 'src/models/document_detection_config.dart';
 // Services
 export 'src/services/cam_scanner_service.dart';
 export 'src/services/camera_service.dart';
 export 'src/services/image_processing_service.dart';
 export 'src/services/ocr_service.dart';
 export 'src/services/pdf_generation_service.dart';
-
-// Models
-export 'src/models/document_capture_data.dart';
-export 'src/models/document_detection_config.dart';
-
 // Main widget
 export 'src/ui/page/document_camera_frame.dart';
-export 'src/core/document_camera_style.dart';
-
 // UI widgets
 export 'src/ui/widgets/action_button.dart';
 export 'src/ui/widgets/captured_image_preview.dart';
+export 'src/ui/widgets/document_camera_preview_layer.dart';
 export 'src/ui/widgets/frame_capture_animation.dart';
 export 'src/ui/widgets/screen_title.dart';
 export 'src/ui/widgets/side_indicator.dart';
 export 'src/ui/widgets/two_sided_action_buttons.dart';
 export 'src/ui/widgets/two_sided_animated_frame.dart';
 export 'src/ui/widgets/two_sided_bottom_frame_container.dart';
-export 'package:camera/camera.dart' show FlashMode;

--- a/lib/src/logic/document_camera_logic.dart
+++ b/lib/src/logic/document_camera_logic.dart
@@ -7,6 +7,7 @@ import '../controllers/document_camera_controller.dart';
 import '../core/app_constants.dart';
 import '../core/enums.dart';
 import '../models/document_capture_data.dart';
+import '../models/document_detection_config.dart';
 import '../services/document_detection_service.dart';
 import '../services/ocr_service.dart';
 import '../services/pdf_generation_service.dart';
@@ -27,6 +28,7 @@ class DocumentCameraLogic {
   final int imageQuality;
   final FlashMode initialFlashMode;
   final DocumentCameraUIMode uiMode;
+  final DocumentDetectionConfig detectionConfig;
 
   DocumentCameraLogic({
     required this.context,
@@ -44,6 +46,7 @@ class DocumentCameraLogic {
     this.imageQuality = 90,
     this.initialFlashMode = FlashMode.auto,
     required this.uiMode,
+    this.detectionConfig = const DocumentDetectionConfig(),
   });
 
   Timer? _debounceTimer;
@@ -99,6 +102,7 @@ class DocumentCameraLogic {
     if (enableAutoCapture) {
       documentDetectionService = DocumentDetectionService(
         onError: (e) => onCameraError?.call(),
+        config: detectionConfig,
       );
       documentDetectionService!.initialize();
     }

--- a/lib/src/logic/document_camera_logic.dart
+++ b/lib/src/logic/document_camera_logic.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 
@@ -8,6 +9,7 @@ import '../core/app_constants.dart';
 import '../core/enums.dart';
 import '../models/document_capture_data.dart';
 import '../models/document_detection_config.dart';
+import '../models/document_detection_status.dart';
 import '../services/document_detection_service.dart';
 import '../services/ocr_service.dart';
 import '../services/pdf_generation_service.dart';
@@ -59,16 +61,11 @@ class DocumentCameraLogic {
   final ValueNotifier<bool> isInitializedNotifier = ValueNotifier(false);
   final ValueNotifier<bool> isLoadingNotifier = ValueNotifier(false);
   final ValueNotifier<String> capturedImageNotifier = ValueNotifier('');
-  final ValueNotifier<DocumentSide> currentSideNotifier = ValueNotifier(
-    DocumentSide.front,
-  );
-  final ValueNotifier<DocumentCaptureData> documentDataNotifier = ValueNotifier(
-    DocumentCaptureData(),
-  );
+  final ValueNotifier<DocumentSide> currentSideNotifier = ValueNotifier(DocumentSide.front);
+  final ValueNotifier<DocumentCaptureData> documentDataNotifier = ValueNotifier(DocumentCaptureData());
   final ValueNotifier<bool> isDocumentAlignedNotifier = ValueNotifier(false);
-  final ValueNotifier<String?> detectionStatusNotifier = ValueNotifier<String?>(
-    null,
-  );
+  final ValueNotifier<String?> detectionStatusNotifier = ValueNotifier<String?>(null);
+  final ValueNotifier<DocumentDetectionStatus?> detectionStatusEnumNotifier = ValueNotifier<DocumentDetectionStatus?>(null);
 
   bool isDetectorBusy = false;
   bool isImageStreamActive = false;
@@ -78,11 +75,7 @@ class DocumentCameraLogic {
 
   bool get _isMinimal => uiMode == DocumentCameraUIMode.minimal;
 
-  void initialize({
-    required double frameWidth,
-    required double frameHeight,
-    int? cameraIndex,
-  }) {
+  void initialize({required double frameWidth, required double frameHeight, int? cameraIndex}) {
     _calculateFrameDimensions(frameWidth, frameHeight);
     _initializeComponents(cameraIndex);
   }
@@ -100,10 +93,7 @@ class DocumentCameraLogic {
 
   Future<void> _initializeComponents(int? cameraIndex) async {
     if (enableAutoCapture) {
-      documentDetectionService = DocumentDetectionService(
-        onError: (e) => onCameraError?.call(),
-        config: detectionConfig,
-      );
+      documentDetectionService = DocumentDetectionService(onError: (e) => onCameraError?.call(), config: detectionConfig);
       documentDetectionService!.initialize();
     }
 
@@ -112,11 +102,7 @@ class DocumentCameraLogic {
 
   Future<void> initializeCamera(int? cameraIndex) async {
     try {
-      await controller.initialize(
-        cameraIndex ?? 0,
-        imageFormatGroup: ImageFormatGroup.nv21,
-        initialFlashMode: initialFlashMode,
-      );
+      await controller.initialize(cameraIndex ?? 0, imageFormatGroup: ImageFormatGroup.nv21, initialFlashMode: initialFlashMode);
       isInitializedNotifier.value = true;
 
       if (enableAutoCapture) {
@@ -129,9 +115,7 @@ class DocumentCameraLogic {
   }
 
   Future<void> startImageStream() async {
-    if (isImageStreamActive ||
-        controller.cameraController == null ||
-        !controller.cameraController!.value.isInitialized) {
+    if (isImageStreamActive || controller.cameraController == null || !controller.cameraController!.value.isInitialized) {
       return;
     }
 
@@ -147,9 +131,7 @@ class DocumentCameraLogic {
 
   Future<void> stopImageStream() async {
     final camController = controller.cameraController;
-    if (!isImageStreamActive ||
-        camController == null ||
-        !camController.value.isStreamingImages) {
+    if (!isImageStreamActive || camController == null || !camController.value.isStreamingImages) {
       return;
     }
 
@@ -189,6 +171,9 @@ class DocumentCameraLogic {
         onStatusUpdated: (status) {
           detectionStatusNotifier.value = status;
         },
+        onStatusNotified: (status) {
+          detectionStatusEnumNotifier.value = status;
+        },
       );
 
       isDocumentAlignedNotifier.value = isAligned;
@@ -199,11 +184,7 @@ class DocumentCameraLogic {
 
           _debounceTimer = Timer(const Duration(seconds: 1), () async {
             if (isDocumentAlignedNotifier.value) {
-              await captureAndHandleImageUnified(
-                context,
-                MediaQuery.of(context).size.width.toInt(),
-                MediaQuery.of(context).size.height.toInt(),
-              );
+              await captureAndHandleImageUnified(context, MediaQuery.of(context).size.width.toInt(), MediaQuery.of(context).size.height.toInt());
             }
             _isDebouncing = false;
             _debounceTimer = null;
@@ -224,11 +205,7 @@ class DocumentCameraLogic {
     }
   }
 
-  Future<void> captureAndHandleImageUnified(
-    BuildContext context,
-    int screenWidth,
-    int screenHeight,
-  ) async {
+  Future<void> captureAndHandleImageUnified(BuildContext context, int screenWidth, int screenHeight) async {
     if (isLoadingNotifier.value) {
       return;
     }
@@ -240,18 +217,9 @@ class DocumentCameraLogic {
         await stopImageStream();
       }
 
-      final double heightToCapture = _isMinimal
-          ? updatedFrameHeight
-          : updatedFrameHeight + AppConstants.bottomFrameContainerHeight;
+      final double heightToCapture = _isMinimal ? updatedFrameHeight : updatedFrameHeight + AppConstants.bottomFrameContainerHeight;
 
-      await controller.takeAndCropPicture(
-        updatedFrameWidth,
-        heightToCapture,
-        screenWidth,
-        screenHeight,
-        outputFormat: outputFormat,
-        imageQuality: imageQuality,
-      );
+      await controller.takeAndCropPicture(updatedFrameWidth, heightToCapture, screenWidth, screenHeight, outputFormat: outputFormat, imageQuality: imageQuality);
 
       capturedImageNotifier.value = controller.previewPath;
       _handleCapture(controller.imagePath);
@@ -269,16 +237,10 @@ class DocumentCameraLogic {
     final effectivePreview = previewPath ?? controller.previewPath;
 
     if (currentSide == DocumentSide.front) {
-      documentDataNotifier.value = currentData.copyWith(
-        frontImagePath: imagePath,
-        frontPreviewPath: effectivePreview,
-      );
+      documentDataNotifier.value = currentData.copyWith(frontImagePath: imagePath, frontPreviewPath: effectivePreview);
       onFrontCaptured?.call(imagePath);
     } else {
-      documentDataNotifier.value = currentData.copyWith(
-        backImagePath: imagePath,
-        backPreviewPath: effectivePreview,
-      );
+      documentDataNotifier.value = currentData.copyWith(backImagePath: imagePath, backPreviewPath: effectivePreview);
       onBackCaptured?.call(imagePath);
     }
   }
@@ -295,8 +257,7 @@ class DocumentCameraLogic {
       capturedImageNotifier.value = controller.imagePath;
     }
 
-    if (enableAutoCapture &&
-        (data.backImagePath == null || data.backImagePath!.isEmpty)) {
+    if (enableAutoCapture && (data.backImagePath == null || data.backImagePath!.isEmpty)) {
       restartImageStreamSafely();
     }
   }
@@ -313,16 +274,14 @@ class DocumentCameraLogic {
       capturedImageNotifier.value = controller.imagePath;
     }
 
-    if (enableAutoCapture &&
-        (data.frontImagePath == null || data.frontImagePath!.isEmpty)) {
+    if (enableAutoCapture && (data.frontImagePath == null || data.frontImagePath!.isEmpty)) {
       restartImageStreamSafely();
     }
   }
 
   Future<void> handleSave() async {
     final data = documentDataNotifier.value;
-    if (!requireBothSides ||
-        data.isCompleteFor(requireBothSides: requireBothSides)) {
+    if (!requireBothSides || data.isCompleteFor(requireBothSides: requireBothSides)) {
       DocumentCaptureData resultData = data;
 
       // ── OCR ────────────────────────────────────────────────────────────────
@@ -333,19 +292,10 @@ class DocumentCameraLogic {
           final frontPath = data.frontPreviewPath ?? data.frontImagePath;
           final backPath = data.backPreviewPath ?? data.backImagePath;
           final results = await Future.wait<String?>([
-            if (frontPath != null && frontPath.isNotEmpty)
-              ocrService.extractText(frontPath)
-            else
-              Future<String?>.value(null),
-            if (backPath != null && backPath.isNotEmpty)
-              ocrService.extractText(backPath)
-            else
-              Future<String?>.value(null),
+            if (frontPath != null && frontPath.isNotEmpty) ocrService.extractText(frontPath) else Future<String?>.value(null),
+            if (backPath != null && backPath.isNotEmpty) ocrService.extractText(backPath) else Future<String?>.value(null),
           ]);
-          resultData = data.copyWith(
-            frontOcrText: results[0],
-            backOcrText: results[1],
-          );
+          resultData = data.copyWith(frontOcrText: results[0], backOcrText: results[1]);
         } catch (e) {
           debugPrint('OCR extraction failed: $e');
         } finally {
@@ -362,12 +312,7 @@ class DocumentCameraLogic {
           final backPath = resultData.backImagePath;
 
           if (frontPath != null && frontPath.isNotEmpty) {
-            final pdfPath = await pdfService.generatePdf(
-              frontImagePath: frontPath,
-              backImagePath: backPath,
-              pageSize: pdfPageSize,
-              imageQuality: imageQuality,
-            );
+            final pdfPath = await pdfService.generatePdf(frontImagePath: frontPath, backImagePath: backPath, pageSize: pdfPageSize, imageQuality: imageQuality);
 
             // Clean up temporary image files after PDF generation.
             try {
@@ -381,11 +326,7 @@ class DocumentCameraLogic {
               debugPrint('Failed to delete temporary image files: $e');
             }
 
-            resultData = DocumentCaptureData(
-              pdfPath: pdfPath,
-              frontOcrText: resultData.frontOcrText,
-              backOcrText: resultData.backOcrText,
-            );
+            resultData = DocumentCaptureData(pdfPath: pdfPath, frontOcrText: resultData.frontOcrText, backOcrText: resultData.backOcrText);
           }
         } catch (e) {
           debugPrint('PDF generation failed: $e');
@@ -483,6 +424,7 @@ class DocumentCameraLogic {
     documentDataNotifier.dispose();
     isDocumentAlignedNotifier.dispose();
     detectionStatusNotifier.dispose();
+    detectionStatusEnumNotifier.dispose();
     _debounceTimer?.cancel();
     _debounceTimer = null;
   }

--- a/lib/src/models/document_detection_config.dart
+++ b/lib/src/models/document_detection_config.dart
@@ -1,0 +1,28 @@
+/// Configuration for document alignment detection thresholds used by
+/// [DocumentDetectionService] during auto-capture.
+final class DocumentDetectionConfig {
+  /// Minimum ratio of the detected object area to the frame area.
+  ///
+  /// Objects smaller than this threshold are considered too far from the camera
+  /// and trigger a "Move closer" hint. Defaults to `0.50` (50 %).
+  final double minSizeRatio;
+
+  /// Maximum ratio of the detected object area to the frame area.
+  ///
+  /// Objects larger than this threshold are considered too close and trigger a
+  /// "Move farther away" hint. Defaults to `0.70` (70 %).
+  final double maxSizeRatio;
+
+  /// Position tolerance as a fraction of the frame bounds.
+  ///
+  /// `0.0` means the detected object must lie strictly within the frame.
+  /// Increase slightly (e.g. `0.05`) to allow a minor border overrun.
+  /// Defaults to `0.0`.
+  final double frameTolerance;
+
+  const DocumentDetectionConfig({this.minSizeRatio = 0.50, this.maxSizeRatio = 0.70, this.frameTolerance = 0.0})
+    : assert(minSizeRatio >= 0.0 && minSizeRatio <= 1.0),
+      assert(maxSizeRatio > 0.0 && maxSizeRatio <= 1.0),
+      assert(minSizeRatio < maxSizeRatio),
+      assert(frameTolerance >= 0.0 && frameTolerance <= 1.0);
+}

--- a/lib/src/models/document_detection_status.dart
+++ b/lib/src/models/document_detection_status.dart
@@ -1,0 +1,38 @@
+/// Represents the alignment guidance state of a document within the camera frame.
+///
+/// Emitted alongside the human-readable [onStatusUpdated] string so callers
+/// can branch on known states rather than parsing text.
+///
+/// Priority order when multiple conditions are true:
+///   [aligned] > size ([tooSmall] / [tooLarge]) > overflow > directional
+enum DocumentDetectionStatus {
+  /// No document was detected in the camera frame.
+  noDocumentFound,
+
+  /// Document is perfectly aligned — ready for capture.
+  aligned,
+
+  /// Document fills too little of the frame — user should move closer.
+  tooSmall,
+
+  /// Document fills too much of the frame — user should move farther away.
+  tooLarge,
+
+  /// Document is too far to the left — user should move right.
+  tooFarLeft,
+
+  /// Document is too far to the right — user should move left.
+  tooFarRight,
+
+  /// Document is too high — user should tilt/move down.
+  tooHigh,
+
+  /// Document is too low — user should tilt/move up.
+  tooLow,
+
+  /// Document overflows both the top and bottom edges of the frame.
+  documentOverflows,
+
+  /// Fallback — position needs adjustment but no specific direction is dominant.
+  adjustPosition,
+}

--- a/lib/src/services/document_detection_service.dart
+++ b/lib/src/services/document_detection_service.dart
@@ -2,6 +2,7 @@ import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:google_mlkit_object_detection/google_mlkit_object_detection.dart';
 
+import '../models/document_detection_config.dart';
 import 'image_converter_service.dart';
 
 /// Service responsible for detecting documents in a live camera stream.
@@ -22,7 +23,13 @@ class DocumentDetectionService {
   /// Useful for surfacing errors to the UI or logging layer without throwing.
   final void Function(Object error)? onError;
 
-  DocumentDetectionService({this.onError});
+  /// Detection thresholds used during alignment evaluation.
+  final DocumentDetectionConfig config;
+
+  DocumentDetectionService({
+    this.onError,
+    this.config = const DocumentDetectionConfig(),
+  });
 
   late final ObjectDetector _objectDetector;
   bool _isDetectorInitialized = false;
@@ -187,17 +194,11 @@ class DocumentDetectionService {
           ((frameTopOnPreview / fittedPreviewHeight) * analysisHeight).round();
 
       // ---------------------------------------------------------------------------
-      // STEP 5: Alignment thresholds
+      // STEP 5: Alignment thresholds (from config)
       // ---------------------------------------------------------------------------
-      // Size thresholds: document should fill between 50% and 70% of the frame area.
-      //   - Lower bound (50%): allows partial or smaller documents.
-      //   - Upper bound (70%): rejects detections that overflow the frame.
-      const double minSizeRatio = 0.50;
-      const double maxSizeRatio = 0.70;
-
-      // Position tolerance: 0% means strictly within the frame bounds.
-      // Increase slightly (e.g., 0.05) to allow minor overrun.
-      const double frameTolerance = 0.0;
+      final double minSizeRatio = config.minSizeRatio;
+      final double maxSizeRatio = config.maxSizeRatio;
+      final double frameTolerance = config.frameTolerance;
 
       final double relaxedFrameTop = cropY * (1 - frameTolerance);
       final double relaxedFrameBottom =

--- a/lib/src/services/document_detection_service.dart
+++ b/lib/src/services/document_detection_service.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:google_mlkit_object_detection/google_mlkit_object_detection.dart';
 
 import '../models/document_detection_config.dart';
+import '../models/document_detection_status.dart';
 import 'image_converter_service.dart';
 
 /// Service responsible for detecting documents in a live camera stream.
@@ -26,10 +27,7 @@ class DocumentDetectionService {
   /// Detection thresholds used during alignment evaluation.
   final DocumentDetectionConfig config;
 
-  DocumentDetectionService({
-    this.onError,
-    this.config = const DocumentDetectionConfig(),
-  });
+  DocumentDetectionService({this.onError, this.config = const DocumentDetectionConfig()});
 
   late final ObjectDetector _objectDetector;
   bool _isDetectorInitialized = false;
@@ -51,16 +49,13 @@ class DocumentDetectionService {
 
     final options = ObjectDetectorOptions(
       mode: DetectionMode.stream, // Optimized for live camera frames
-      classifyObjects:
-          false, // Classification not needed for document detection
+      classifyObjects: false, // Classification not needed for document detection
       multipleObjects: true, // Detect all candidates, pick best one later
     );
 
     _objectDetector = ObjectDetector(options: options);
     _isDetectorInitialized = true;
-    debugPrint(
-      '[DocumentDetectionService] initialize: ObjectDetector initialized',
-    );
+    debugPrint('[DocumentDetectionService] initialize: ObjectDetector initialized');
   }
 
   /// Closes the [ObjectDetector] and releases its native resources.
@@ -104,14 +99,13 @@ class DocumentDetectionService {
     required int screenWidth,
     required int screenHeight,
     ValueChanged<String>? onStatusUpdated,
+    ValueChanged<DocumentDetectionStatus>? onStatusNotified,
     ValueChanged<List<Rect>>? onDetectedRectUpdated,
     ValueChanged<Rect?>? onBestDetectedRectUpdated,
   }) async {
     // Guard: detector must be initialized before processing frames
     if (!_isDetectorInitialized) {
-      debugPrint(
-        '[DocumentDetectionService] processImage: Detector not initialized',
-      );
+      debugPrint('[DocumentDetectionService] processImage: Detector not initialized');
       return false;
     }
 
@@ -130,13 +124,12 @@ class DocumentDetectionService {
       // ---------------------------------------------------------------------------
       // STEP 2: Run ML Kit object detection
       // ---------------------------------------------------------------------------
-      final List<DetectedObject> objects = await _objectDetector.processImage(
-        inputImage,
-      );
+      final List<DetectedObject> objects = await _objectDetector.processImage(inputImage);
 
       // If nothing was detected, notify the UI and return early
       if (objects.isEmpty) {
         onStatusUpdated?.call('No document found');
+        onStatusNotified?.call(DocumentDetectionStatus.noDocumentFound);
         onDetectedRectUpdated?.call(<Rect>[]);
         onBestDetectedRectUpdated?.call(null);
         return false;
@@ -168,9 +161,7 @@ class DocumentDetectionService {
 
       // Compute the preview's true aspect ratio from camera-reported dimensions.
       // Fallback to analysis dimensions if previewSize is unavailable.
-      final double previewAspectRatio = previewSize != null
-          ? previewSize.height / previewSize.width
-          : analysisHeight / analysisWidth;
+      final double previewAspectRatio = previewSize != null ? previewSize.height / previewSize.width : analysisHeight / analysisWidth;
 
       // The preview is fitted to the display width. Its full (unclipped) height
       // may exceed the visible display area, creating a vertical letterbox offset.
@@ -181,8 +172,7 @@ class DocumentDetectionService {
       // Width uses display width ratio; height uses fittedPreviewHeight (not displayHeight)
       // to correctly account for the letterbox offset.
       final int cropWidth = (frameWidth / displayWidth * analysisWidth).round();
-      final int cropHeight =
-          (frameHeight / fittedPreviewHeight * analysisHeight).round();
+      final int cropHeight = (frameHeight / fittedPreviewHeight * analysisHeight).round();
 
       // Horizontal center of the frame in analysis space
       final int cropX = (analysisWidth - cropWidth) ~/ 2;
@@ -190,8 +180,7 @@ class DocumentDetectionService {
       // Vertical position of the frame top, adjusted for letterbox offset
       final double frameTopOnScreen = (displayHeight - frameHeight) / 2;
       final double frameTopOnPreview = frameTopOnScreen + verticalOffset;
-      final int cropY =
-          ((frameTopOnPreview / fittedPreviewHeight) * analysisHeight).round();
+      final int cropY = ((frameTopOnPreview / fittedPreviewHeight) * analysisHeight).round();
 
       // ---------------------------------------------------------------------------
       // STEP 5: Alignment thresholds (from config)
@@ -201,8 +190,7 @@ class DocumentDetectionService {
       final double frameTolerance = config.frameTolerance;
 
       final double relaxedFrameTop = cropY * (1 - frameTolerance);
-      final double relaxedFrameBottom =
-          (cropY + cropHeight) * (1 + frameTolerance);
+      final double relaxedFrameBottom = (cropY + cropHeight) * (1 + frameTolerance);
       final double frameArea = (cropWidth * cropHeight).toDouble();
 
       // The target aspect ratio of the document frame (portrait = height/width > 1)
@@ -212,23 +200,15 @@ class DocumentDetectionService {
       // STEP 6: Filter objects to candidates within the frame
       // ---------------------------------------------------------------------------
       // A candidate must satisfy both size and position constraints.
-      final bool isFrontCamera =
-          cameraController.description.lensDirection ==
-          CameraLensDirection.front;
+      final bool isFrontCamera = cameraController.description.lensDirection == CameraLensDirection.front;
 
       final List<DetectedObject> filteredObjects = objects.where((object) {
         final rect = object.boundingBox;
         if (rect.width <= 0 || rect.height <= 0) return false;
 
         final double area = rect.width * rect.height;
-        final bool sizeOk =
-            area > (minSizeRatio * frameArea) &&
-            area < (maxSizeRatio * frameArea);
-        final bool posOk =
-            rect.left >= cropX &&
-            rect.top >= relaxedFrameTop &&
-            rect.right <= (cropX + cropWidth) &&
-            rect.bottom <= relaxedFrameBottom;
+        final bool sizeOk = area > (minSizeRatio * frameArea) && area < (maxSizeRatio * frameArea);
+        final bool posOk = rect.left >= cropX && rect.top >= relaxedFrameTop && rect.right <= (cropX + cropWidth) && rect.bottom <= relaxedFrameBottom;
         return sizeOk && posOk;
       }).toList();
 
@@ -260,14 +240,9 @@ class DocumentDetectionService {
       // If filtered candidates exist, pick the best among them.
       // Otherwise, fall back to all detected objects so we can still give
       // guidance even when no object fully satisfies the constraints.
-      final List<DetectedObject> selectionPool = filteredObjects.isNotEmpty
-          ? filteredObjects
-          : objects;
+      final List<DetectedObject> selectionPool = filteredObjects.isNotEmpty ? filteredObjects : objects;
 
-      final DetectedObject bestObject = _selectBestDetectedObject(
-        selectionPool,
-        targetAspectRatio: targetAspectRatio,
-      );
+      final DetectedObject bestObject = _selectBestDetectedObject(selectionPool, targetAspectRatio: targetAspectRatio);
 
       // Map the best candidate to screen space and report it
       final Rect? bestRectOnScreen = _mapBoundingBoxToScreenRect(
@@ -281,9 +256,7 @@ class DocumentDetectionService {
         isMirrored: isFrontCamera,
       );
       // Only surface the best rect if it passed all filters
-      onBestDetectedRectUpdated?.call(
-        filteredObjects.isNotEmpty ? bestRectOnScreen : null,
-      );
+      onBestDetectedRectUpdated?.call(filteredObjects.isNotEmpty ? bestRectOnScreen : null);
 
       // ---------------------------------------------------------------------------
       // STEP 9: Final alignment evaluation
@@ -291,15 +264,10 @@ class DocumentDetectionService {
       final Rect boundingBox = bestObject.boundingBox;
       final double objectArea = boundingBox.width * boundingBox.height;
 
-      final bool sizeAligned =
-          objectArea > (minSizeRatio * frameArea) &&
-          objectArea < (maxSizeRatio * frameArea);
+      final bool sizeAligned = objectArea > (minSizeRatio * frameArea) && objectArea < (maxSizeRatio * frameArea);
 
       final bool positionAligned =
-          boundingBox.left >= cropX &&
-          boundingBox.top >= relaxedFrameTop &&
-          boundingBox.right <= (cropX + cropWidth) &&
-          boundingBox.bottom <= relaxedFrameBottom;
+          boundingBox.left >= cropX && boundingBox.top >= relaxedFrameTop && boundingBox.right <= (cropX + cropWidth) && boundingBox.bottom <= relaxedFrameBottom;
 
       final bool isAligned = sizeAligned && positionAligned;
 
@@ -336,16 +304,19 @@ class DocumentDetectionService {
       // ---------------------------------------------------------------------------
       // Compute directional adjustment hints when position is off
       final List<String> adjustments = [];
-      if (!positionAligned) {
-        if (boundingBox.left < cropX) {
-          adjustments.add('Move right');
-        }
-        if (boundingBox.right > cropX + cropWidth) {
-          adjustments.add('Move left');
-        }
+      bool overLeft = false;
+      bool overRight = false;
+      bool overTop = false;
+      bool overBottom = false;
 
-        final bool overTop = boundingBox.top < relaxedFrameTop;
-        final bool overBottom = boundingBox.bottom > relaxedFrameBottom;
+      if (!positionAligned) {
+        overLeft = boundingBox.left < cropX;
+        overRight = boundingBox.right > cropX + cropWidth;
+        overTop = boundingBox.top < relaxedFrameTop;
+        overBottom = boundingBox.bottom > relaxedFrameBottom;
+
+        if (overLeft) adjustments.add('Move right');
+        if (overRight) adjustments.add('Move left');
 
         if (overTop && overBottom) {
           adjustments.add('Document overflows top and bottom');
@@ -374,6 +345,7 @@ class DocumentDetectionService {
       // Emit the guidance message to the UI
       _updateDetectionStatus(
         onStatusUpdated,
+        onStatusNotified,
         isAligned: isAligned,
         adjustments: adjustments,
         sizeAligned: sizeAligned,
@@ -381,6 +353,10 @@ class DocumentDetectionService {
         maxSizeRatio: maxSizeRatio,
         objectArea: objectArea,
         frameArea: frameArea,
+        overLeft: overLeft,
+        overRight: overRight,
+        overTop: overTop,
+        overBottom: overBottom,
       );
 
       return isAligned;
@@ -402,10 +378,7 @@ class DocumentDetectionService {
   ///
   /// Ties in aspect ratio difference are broken by choosing the larger object,
   /// since a larger detection is more likely to represent the full document.
-  DetectedObject _selectBestDetectedObject(
-    List<DetectedObject> objects, {
-    required double targetAspectRatio,
-  }) {
+  DetectedObject _selectBestDetectedObject(List<DetectedObject> objects, {required double targetAspectRatio}) {
     DetectedObject best = objects.first;
     double bestAspectDiff = double.infinity;
     double bestArea = -1;
@@ -419,8 +392,7 @@ class DocumentDetectionService {
       final double area = rect.width * rect.height;
 
       // Prefer closer aspect ratio; break ties by larger area
-      if (aspectDiff < bestAspectDiff ||
-          (aspectDiff == bestAspectDiff && area > bestArea)) {
+      if (aspectDiff < bestAspectDiff || (aspectDiff == bestAspectDiff && area > bestArea)) {
         best = object;
         bestAspectDiff = aspectDiff;
         bestArea = area;
@@ -494,7 +466,8 @@ Rect? _mapBoundingBoxToScreenRect({
 ///   4. Both off      → combined position + size message
 ///   5. Fallback      → 'Adjust document position'
 void _updateDetectionStatus(
-  ValueChanged<String>? onStatusUpdated, {
+  ValueChanged<String>? onStatusUpdated,
+  ValueChanged<DocumentDetectionStatus>? onStatusNotified, {
   required bool isAligned,
   required List<String> adjustments,
   required bool sizeAligned,
@@ -502,7 +475,23 @@ void _updateDetectionStatus(
   required double maxSizeRatio,
   required double objectArea,
   required double frameArea,
+  required bool overLeft,
+  required bool overRight,
+  required bool overTop,
+  required bool overBottom,
 }) {
+  // Resolve enum status first (drives both notifiers)
+  final DocumentDetectionStatus status = _resolveStatus(
+    isAligned: isAligned,
+    sizeAligned: sizeAligned,
+    objectTooSmall: objectArea < (minSizeRatio * frameArea),
+    overLeft: overLeft,
+    overRight: overRight,
+    overTop: overTop,
+    overBottom: overBottom,
+  );
+  onStatusNotified?.call(status);
+
   if (onStatusUpdated == null) return;
 
   // Document is fully aligned — prompt the user to hold still for capture
@@ -538,4 +527,28 @@ void _updateDetectionStatus(
   }
 
   onStatusUpdated(message);
+}
+
+/// Resolves the primary [DocumentDetectionStatus] from alignment boolean flags.
+///
+/// Priority: aligned > size (tooSmall/tooLarge) > overflow > directional > fallback.
+DocumentDetectionStatus _resolveStatus({
+  required bool isAligned,
+  required bool sizeAligned,
+  required bool objectTooSmall,
+  required bool overLeft,
+  required bool overRight,
+  required bool overTop,
+  required bool overBottom,
+}) {
+  if (isAligned) return DocumentDetectionStatus.aligned;
+  if (!sizeAligned) {
+    return objectTooSmall ? DocumentDetectionStatus.tooSmall : DocumentDetectionStatus.tooLarge;
+  }
+  if (overTop && overBottom) return DocumentDetectionStatus.documentOverflows;
+  if (overLeft) return DocumentDetectionStatus.tooFarLeft;
+  if (overRight) return DocumentDetectionStatus.tooFarRight;
+  if (overTop) return DocumentDetectionStatus.tooHigh;
+  if (overBottom) return DocumentDetectionStatus.tooLow;
+  return DocumentDetectionStatus.adjustPosition;
 }

--- a/lib/src/services/image_processing_service.dart
+++ b/lib/src/services/image_processing_service.dart
@@ -36,8 +36,20 @@ class ImageProcessingService {
       imageFile.readAsBytesSync(),
     )!;
 
-    final int cropWidth = originalImage.width * frameWidth ~/ screenWidth;
-    final int cropHeight = originalImage.height * frameHeight ~/ screenHeight;
+    // The preview is rendered with cover-fit (see _CoverFitCameraPreview):
+    // the captured image is scaled by `coverScale = max(scrW/imgW, scrH/imgH)`
+    // and centered, with the longer axis overflowing off-screen. To map the
+    // on-screen frame back to image-pixel space we divide by that same scale,
+    // which keeps the crop rectangle visually identical to the frame the user
+    // saw — no aspect distortion, no offset.
+    final double scaleX = screenWidth / originalImage.width;
+    final double scaleY = screenHeight / originalImage.height;
+    final double coverScale = scaleX > scaleY ? scaleX : scaleY;
+
+    int cropWidth = (frameWidth / coverScale).round();
+    int cropHeight = (frameHeight / coverScale).round();
+    if (cropWidth > originalImage.width) cropWidth = originalImage.width;
+    if (cropHeight > originalImage.height) cropHeight = originalImage.height;
 
     final int cropX = (originalImage.width - cropWidth) ~/ 2;
     final int cropY = (originalImage.height - cropHeight) ~/ 2;

--- a/lib/src/ui/page/document_camera_frame.dart
+++ b/lib/src/ui/page/document_camera_frame.dart
@@ -112,6 +112,12 @@ class DocumentCameraFrame extends StatefulWidget {
   ///   but with on-device OCR automatically enabled.
   final DocumentCameraUIMode uiMode;
 
+  /// Tuning parameters for the document alignment detector used during
+  /// auto-capture (size ratios, position tolerance).
+  ///
+  /// Has no effect when auto-capture is disabled or in camScanner mode.
+  final DocumentDetectionConfig detectionConfig;
+
   /// Constructor for the [DocumentCameraFrame].
   const DocumentCameraFrame({
     super.key,
@@ -144,6 +150,7 @@ class DocumentCameraFrame extends StatefulWidget {
     this.imageQuality = 90,
     this.initialFlashMode = FlashMode.auto,
     this.uiMode = DocumentCameraUIMode.defaultMode,
+    this.detectionConfig = const DocumentDetectionConfig(),
   });
 
   bool get _isCamScanner => uiMode == DocumentCameraUIMode.camScanner;
@@ -217,6 +224,7 @@ class _DocumentCameraFrameState extends State<DocumentCameraFrame>
         imageQuality: widget.imageQuality,
         initialFlashMode: widget.initialFlashMode,
         uiMode: widget.uiMode,
+        detectionConfig: widget.detectionConfig,
       );
       WidgetsBinding.instance.addPostFrameCallback((_) => _launchCamScanner());
       return;
@@ -240,6 +248,7 @@ class _DocumentCameraFrameState extends State<DocumentCameraFrame>
       imageQuality: widget.imageQuality,
       initialFlashMode: widget.initialFlashMode,
       uiMode: widget.uiMode,
+      detectionConfig: widget.detectionConfig,
     );
 
     if (widget._effectiveShowSideIndicator) {

--- a/lib/src/ui/widgets/document_camera_preview_layer.dart
+++ b/lib/src/ui/widgets/document_camera_preview_layer.dart
@@ -50,9 +50,13 @@ class DocumentCameraPreviewLayer extends StatelessWidget {
         return Stack(
           fit: StackFit.expand,
           children: [
-            // Camera preview
+            // Camera preview — cover-fit so the sensor aspect is preserved
+            // (no horizontal/vertical squeeze). One axis is scaled up to fill
+            // the screen; overflow on the other axis is clipped.
             if (logic.controller.cameraController != null)
-              CameraPreview(logic.controller.cameraController!),
+              _CoverFitCameraPreview(
+                controller: logic.controller.cameraController!,
+              ),
 
             // Captured image preview
             CapturedImagePreview(
@@ -82,6 +86,34 @@ class DocumentCameraPreviewLayer extends StatelessWidget {
           ],
         );
       },
+    );
+  }
+}
+
+/// Workaround for the stretched/squeezed `CameraPreview` when the camera
+/// sensor aspect ratio doesn't match the screen.
+///
+/// Known upstream issue (camera plugin): https://github.com/flutter/flutter/issues/180499
+/// Solution adapted from: https://stackoverflow.com/questions/49946153/flutter-camera-appears-stretched
+class _CoverFitCameraPreview extends StatelessWidget {
+  final CameraController controller;
+
+  const _CoverFitCameraPreview({required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+    // controller.value.aspectRatio is the preview's landscape aspect ratio (>= 1).
+    // size.aspectRatio is displayWidth / displayHeight (< 1 in portrait).
+    // The product compares screen vs. preview proportions; inverting when < 1
+    // gives the scale factor needed to cover the screen on both axes.
+    var scale = size.aspectRatio * controller.value.aspectRatio;
+    if (scale < 1) scale = 1 / scale;
+    return ClipRect(
+      child: Transform.scale(
+        scale: scale,
+        child: Center(child: CameraPreview(controller)),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Problem

The camera preview inside the document frame was visibly squeezed — sensor pixels were being non-uniformly stretched to fill the screen. Captured crops were also slightly off because the crop math assumed a 1:1 preview-to-screen mapping that didn't actually hold.

## Root cause

`CameraPreview` was placed inside `Stack(fit: StackFit.expand)` (twice — once in the page, once in the preview layer). Tight constraints from the parent overrode the `AspectRatio` widget that `CameraPreview` uses internally to preserve the sensor aspect, forcing the texture to fill the screen and distorting it.

This is a [known upstream issue in the `camera` plugin](https://github.com/flutter/flutter/issues/180499); the standard workaround is documented on [StackOverflow](https://stackoverflow.com/questions/49946153/flutter-camera-appears-stretched).

## Fix

**1. Preview rendering** — `lib/src/ui/widgets/document_camera_preview_layer.dart`
Introduced `_CoverFitCameraPreview`, which wraps `CameraPreview` in `ClipRect` + `Transform.scale` + `Center`. The scale factor is `size.aspectRatio * controller.value.aspectRatio` (inverted when < 1), giving a true `BoxFit.cover` result: no distortion, with the long axis clipped — same look as native camera apps.

**2. Crop math** — `lib/src/services/image_processing_service.dart`
Switched from the stretch-fit linear formula to a uniform cover-scale derived from the captured image's actual dimensions:

```dart
coverScale = max(screenW / imgW, screenH / imgH)
cropWidth  = frameWidth  / coverScale
cropHeight = frameHeight / coverScale
```

This is the same scale at which the captured image is rendered to screen, so the cropped region in image-pixel space corresponds exactly to the frame the user saw on screen. Added bounds clamping for rounding safety.

---

- [x] ID card capture — preview correct, crop correct.
- [x] Passport capture — preview correct, crop correct.
